### PR TITLE
Bug fix: parameter passed to DomainException must be a string

### DIFF
--- a/src/TurboSmsApi.php
+++ b/src/TurboSmsApi.php
@@ -63,7 +63,7 @@ class TurboSmsApi
             if ($result->SendSMSResult->ResultArray[0]
               != 'Сообщения успешно отправлены'
             ) {
-                throw new DomainException($result->SendSMSResult->ResultArray);
+                throw new DomainException($result->SendSMSResult->ResultArray[0]);
             }
 
             return $result;


### PR DESCRIPTION
Parameter passed to DomainException must be a string. In other case have en error: Wrong parameters for DomainException.
Best regards.